### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Gortfolio
 									
 
 
-##under development.......
+## under development.......
 DEMO:[http://glexe.com](http://eisneim.github.io/gortfolio/)
 
 ![img](snapshot.png 'preview')
@@ -24,7 +24,7 @@ using:
  - Mongodb as database
  - Gulp as build tool
 
-##TODO
+## TODO
  - theme system: seperate frontend and backend and make switch to another front end easily;
  - portfolio management:upload, edit, deldate
  - improve or ReWrite some slow page or component


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
